### PR TITLE
Update Default TMax for Marangoni BC

### DIFF
--- a/applications/solvers/additiveFoam/BCs/marangoni/marangoniFvPatchVectorField.C
+++ b/applications/solvers/additiveFoam/BCs/marangoni/marangoniFvPatchVectorField.C
@@ -57,7 +57,7 @@ Foam::marangoniFvPatchVectorField::marangoniFvPatchVectorField
 :
     transformFvPatchField<vector>(p, iF),
     dSigmadT_(dict.lookup<scalar>("dSigmadT")),
-    Tmax_(dict.lookupOrDefault<scalar>("Tmax", 0.0))
+    Tmax_(dict.lookupOrDefault<scalar>("Tmax", GREAT))
 {
     evaluate();
 }

--- a/applications/solvers/additiveFoam/BCs/marangoni/marangoniFvPatchVectorField.C
+++ b/applications/solvers/additiveFoam/BCs/marangoni/marangoniFvPatchVectorField.C
@@ -44,7 +44,7 @@ Foam::marangoniFvPatchVectorField::marangoniFvPatchVectorField
 :
     transformFvPatchField<vector>(p, iF),
     dSigmadT_(0.0),
-    Tmax_(0.0)
+    Tmax_(GREAT)
 {}
 
 


### PR DESCRIPTION
Update default `TMax` parameter for Marangoni boundary condition so that if no parameter is given by the user, fluid flow will occur.

Closes #7.