### PR TITLE
Remove unused libraries from options file

### DIFF
--- a/applications/solvers/additiveFoam/Make/options
+++ b/applications/solvers/additiveFoam/Make/options
@@ -2,6 +2,7 @@ EXE_INC = \
     -I. \
     -ImovingHeatSource/lnInclude \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(LIB_SRC)/meshTools/lnInclude \
     -I$(LIB_SRC)/randomProcesses/lnInclude
 
 EXE_LIBS = \

--- a/applications/solvers/additiveFoam/Make/options
+++ b/applications/solvers/additiveFoam/Make/options
@@ -1,23 +1,12 @@
 EXE_INC = \
     -I. \
     -ImovingHeatSource/lnInclude \
-    -I$(LIB_SRC)/MomentumTransportModels/momentumTransportModels/lnInclude \
-    -I$(LIB_SRC)/MomentumTransportModels/incompressible/lnInclude \
-    -I$(LIB_SRC)/physicalProperties/lnInclude \
-    -I$(LIB_SRC)/sampling/lnInclude \
-    -I$(LIB_SRC)/meshTools/lnInclude \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(LIB_SRC)/randomProcesses/lnInclude
 
 EXE_LIBS = \
     -L$(FOAM_USER_LIBBIN) \
     -lmovingBeamModels \
-    -lmomentumTransportModels \
-    -lincompressibleMomentumTransportModels \
-    -lphysicalProperties \
     -lfiniteVolume \
-    -lfvModels \
-    -lfvConstraints \
-    -lsampling \
     -lmeshTools \
     -lrandomProcesses


### PR DESCRIPTION
This PR removes unnecessary libraries from the `Make/options` file. In the event additional libraries are needed for custom applications, they can be re-added by the user or included in the `controlDict`.