### PR TITLE
Source term and property stabilization

### DIFF
--- a/applications/solvers/additiveFoam/additiveFoam.C
+++ b/applications/solvers/additiveFoam/additiveFoam.C
@@ -42,6 +42,8 @@ Description
 #include "movingHeatSourceModel.H"
 #include "foamToExaCA/foamToExaCA.H"
 
+#include "CrankNicolsonDdtScheme.H"
+
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
 int main(int argc, char *argv[])

--- a/applications/solvers/additiveFoam/readTransportProperties.H
+++ b/applications/solvers/additiveFoam/readTransportProperties.H
@@ -27,7 +27,7 @@ Polynomial<PolySize> Cp3(powderDict.lookup("Cp"));
 // Reference density [kg]
 const dimensionedScalar rho
 (
-    "mu",
+    "rho",
     dimDensity,
     transportProperties.lookup("rho")
 );

--- a/applications/solvers/additiveFoam/thermo/TEqn.H
+++ b/applications/solvers/additiveFoam/thermo/TEqn.H
@@ -1,42 +1,5 @@
 {
-    fvScalarMatrix TEqn(T, dimPower);
-
-    if (explicitSolve)
-    {
-        TEqn =
-        (
-            rho*Cp*(fvm::ddt(T) + fvc::div(phi, T))
-          - fvc::laplacian(kappa, T)
-          - sources.qDot()
-        );
-    }
-    else
-    {
-        TEqn =
-        (
-            rho*Cp*(fvm::ddt(T) + fvm::div(phi, T))
-          - fvm::laplacian(kappa, T)
-          - sources.qDot()
-        );
-    }
-           
-    //- set source term linearization weights for time discretization scheme  
-    scalar coefft = 1;
-    const dimensionedScalar deltaT  = runTime.deltaT();
-    
-    const word ddtScheme = mesh.schemes().ddt(T.name());
-    if ((ddtScheme != "Euler") && (ddtScheme != "backward"))
-    {
-        FatalErrorInFunction
-            << "Unsupported ddtScheme " << ddtScheme
-            << ". Choose either Euler or backward."
-            << abort(FatalError);
-    }
-    else if (ddtScheme == "backward")
-    {
-        const dimensionedScalar deltaT0 = runTime.deltaT0();
-        coefft += (deltaT/(deltaT + deltaT0)).value();    
-    }
+    #include "thermo/thermoScheme.H"
 
     //- solve thermodynamic coupling using root-finding algorithm
     volScalarField dFdT
@@ -62,7 +25,7 @@
         (
             TEqn
          ==
-            coefft*rho*Lf/deltaT*(fvm::Sp(dFdT, T) - dFdT*T0)
+            rDeltaT*rho*Lf*(fvm::Sp(dFdT, T) - dFdT*T0)
           + rho*Lf*fvc::ddt(alpha1)
         );
 

--- a/applications/solvers/additiveFoam/thermo/TEqn.H
+++ b/applications/solvers/additiveFoam/thermo/TEqn.H
@@ -29,7 +29,7 @@
     {
         FatalErrorInFunction
             << "Unsupported ddtScheme " << ddtScheme
-            << ". Choose either Euler or backwards."
+            << ". Choose either Euler or backward."
             << abort(FatalError);
     }
     else if (ddtScheme == "backward")

--- a/applications/solvers/additiveFoam/thermo/TEqn.H
+++ b/applications/solvers/additiveFoam/thermo/TEqn.H
@@ -6,7 +6,7 @@
         TEqn =
         (
             rho*Cp*(fvm::ddt(T) + fvc::div(phi, T))
-          - fvc::laplacian(fvc::interpolate(kappa), T)
+          - fvc::laplacian(kappa, T)
           - sources.qDot()
         );
     }
@@ -15,9 +15,27 @@
         TEqn =
         (
             rho*Cp*(fvm::ddt(T) + fvm::div(phi, T))
-          - fvm::laplacian(fvc::interpolate(kappa), T)
+          - fvm::laplacian(kappa, T)
           - sources.qDot()
         );
+    }
+           
+    //- set source term linearization weights for time discretization scheme  
+    scalar coefft = 1;
+    const dimensionedScalar deltaT  = runTime.deltaT();
+    
+    const word ddtScheme = mesh.schemes().ddt(T.name());
+    if ((ddtScheme != "Euler") && (ddtScheme != "backward"))
+    {
+        FatalErrorInFunction
+            << "Unsupported ddtScheme " << ddtScheme
+            << ". Choose either Euler or backwards."
+            << abort(FatalError);
+    }
+    else if (ddtScheme == "backward")
+    {
+        const dimensionedScalar deltaT0 = runTime.deltaT0();
+        coefft += (deltaT/(deltaT + deltaT0)).value();    
     }
 
     //- solve thermodynamic coupling using root-finding algorithm
@@ -32,12 +50,9 @@
         mesh,
         dimensionedScalar("dFdT", dimless/dimTemperature, 0.0)
     );
-
-    dimensionedScalar dt(runTime.deltaT());
-
+    
     volScalarField T0("T0", T);
-    volScalarField alpha10("alpha10", alpha1);
-
+    
     for (int tCorr=0; tCorr < nThermoCorr; tCorr++)
     {
         #include "thermo/thermoSource.H"
@@ -47,13 +62,14 @@
         (
             TEqn
          ==
-            fvm::Sp(rho*Lf*dFdT/dt, T)
-          + rho*Lf*(alpha10 - alpha1.oldTime() - dFdT*T0)/dt
+            coefft*rho*Lf/deltaT*(fvm::Sp(dFdT, T) - dFdT*T0)
+          + rho*Lf*fvc::ddt(alpha1)
         );
 
         T.correctBoundaryConditions();
 
         //- update solid fraction via Taylor's series expansion
+        volScalarField alpha10("alpha10", alpha1);
         alpha1 = min(max(alpha10 + dFdT*(T - T0), 0.0), 1.0);
         alpha1.correctBoundaryConditions();
 
@@ -64,7 +80,7 @@
         Info<< "Thermo: iteration " << tCorr
             << " residual: " << residual << endl;
 
-        if (residual < thermoTol)
+        if ((residual < thermoTol) && (tCorr > 0))
         {
             break;
         }

--- a/applications/solvers/additiveFoam/thermo/thermoScheme.H
+++ b/applications/solvers/additiveFoam/thermo/thermoScheme.H
@@ -1,0 +1,62 @@
+//- Construct the temperature equation for the time integration scheme
+fvScalarMatrix TEqn(T, dimPower);
+dimensionedScalar rDeltaT = 1.0 / runTime.deltaT();
+
+if (explicitSolve)
+{
+    TEqn =
+    (
+        rho*Cp*(fvm::ddt(T) + fvc::div(phi, T))
+      - fvc::laplacian(kappa, T)
+      - sources.qDot()
+    );
+}
+else
+{
+    TEqn =
+    (
+        rho*Cp*(fvm::ddt(T) + fvm::div(phi, T))
+      - fvm::laplacian(kappa, T)
+      - sources.qDot()
+    );
+
+    scalar coefft = 1.0;
+    
+    const word ddtScheme = mesh.schemes().ddt(T.name());
+
+    if
+    (
+        (ddtScheme != "Euler")
+     && (ddtScheme != "backward")
+     && (ddtScheme != "CrankNicolson")
+    )
+    {
+        FatalErrorInFunction
+            << "Unsupported ddtScheme " << ddtScheme
+            << ". Choose Euler, CrankNicolson, or backward."
+            << abort(FatalError);
+    }
+    else if (ddtScheme == "backward")
+    {
+        const dimensionedScalar deltaT = runTime.deltaT();
+        const dimensionedScalar deltaT0 = runTime.deltaT0();
+        
+        coefft = 1.0 + (deltaT/(deltaT + deltaT0)).value();    
+    }
+    else if (ddtScheme == "CrankNicolson")
+    {
+        scalar ocCoeff =
+            refCast<const fv::CrankNicolsonDdtScheme<scalar>>
+            (
+                fv::ddtScheme<scalar>::New
+                (
+                    mesh,
+                    mesh.schemes().ddt(ddtScheme)
+                )()
+            ).ocCoeff();
+
+        coefft = 1.0 + ocCoeff;
+    }
+    
+    rDeltaT *= coefft;
+}

--- a/applications/solvers/additiveFoam/thermo/thermoScheme.H
+++ b/applications/solvers/additiveFoam/thermo/thermoScheme.H
@@ -1,4 +1,4 @@
-//- Construct the temperature equation for the time integration scheme
+//- Construct the temperature equation for the chosen time integration scheme
 fvScalarMatrix TEqn(T, dimPower);
 dimensionedScalar rDeltaT = 1.0 / runTime.deltaT();
 
@@ -57,6 +57,8 @@ else
 
         coefft = 1.0 + ocCoeff;
     }
+    
+    Info << "thero time coefficient (coefft): " << coefft << endl;
     
     rDeltaT *= coefft;
 }

--- a/applications/solvers/additiveFoam/thermo/thermoSource.H
+++ b/applications/solvers/additiveFoam/thermo/thermoSource.H
@@ -2,16 +2,13 @@
     scalarField xvals(thermo.x());
     const scalarField& yvals(thermo.y());
     label n = xvals.size();
-
     const scalar slope = 1e10;
 
     forAll(mesh.cells(), celli)
     {
-        // update solid fraction estimate
-        alpha10[celli] = alpha1[celli];
-
         // update slope and temperature estimates
-        const scalar x(T[celli]);
+        const scalar& x = T[celli];
+        const scalar& y = alpha1[celli];
 
         if ((x < Tliq.value()) && (x > Tsol.value()))
         {
@@ -49,14 +46,14 @@
 
             dFdT[celli] = (yvals[hi] - yvals[lo]) / (xvals[hi] - xvals[lo]);
 
-            T0[celli] = xvals[lo] + (alpha10[celli] - yvals[lo])/dFdT[celli];
+            T0[celli] = xvals[lo] + (y - yvals[lo])/dFdT[celli];
         }
-        else if ((x >= Tliq.value()) && (alpha10[celli] > 0.0))
+        else if ((x >= Tliq.value()) && (y > thermoTol))
         {
             dFdT[celli] = slope;
             T0[celli] = Tliq.value() - thermoTol;
         }
-        else if ((x <= Tsol.value()) && (alpha10[celli] < 1.0))
+        else if ((x <= Tsol.value()) && (y < 1 - thermoTol))
         {
             dFdT[celli] = slope;
             T0[celli] = Tsol.value() + thermoTol;
@@ -64,15 +61,10 @@
         else
         {
             dFdT[celli] = 0.0;
-            T0[celli] = T[celli];
+            T0[celli] = x;
         }
     }
 
-
-    // update boundary conditions
-    alpha10.correctBoundaryConditions();
-
     dFdT.correctBoundaryConditions();
-
     T0.correctBoundaryConditions();
 }

--- a/applications/solvers/additiveFoam/updateProperties.H
+++ b/applications/solvers/additiveFoam/updateProperties.H
@@ -14,7 +14,7 @@ forAll(mesh.cells(), cellI)
     scalar T1 = min(max(T[cellI], 300.0), Tsol.value());
     scalar T2 = min(max(T[cellI], Tliq.value()), 2.0*Tliq.value());
 
-    //- Update solid-liquid-powder mixture properties    
+    // update solid-liquid-powder mixture properties    
     kappa[cellI] = 
         (1.0 - alpha3_)*(alpha1_*kappa1.value(T1) + alpha2_*kappa2.value(T2))
       + alpha3_*kappa3.value(T1);

--- a/applications/solvers/additiveFoam/updateProperties.H
+++ b/applications/solvers/additiveFoam/updateProperties.H
@@ -1,30 +1,29 @@
-// store old time values
-kappa.oldTime();
-
 forAll(mesh.cells(), cellI)
 {
+    // update phase fractions
     scalar alpha1_ = alpha1[cellI];
     scalar alpha2_ = 1.0 - alpha1[cellI];
-
-    //- Discrete powder-liquid transition model
-    alpha3[cellI] = (alpha2_ > 0.0) ? 0.0 : alpha3[cellI];
+    
+    if (alpha1_ < 1.0)
+    {
+    	alpha3[cellI] = 0.0;
+    }
     scalar alpha3_ = alpha3[cellI];
 
+    // update temperature ranges for phase properties
     scalar T1 = min(max(T[cellI], 300.0), Tsol.value());
     scalar T2 = min(max(T[cellI], Tliq.value()), 2.0*Tliq.value());
 
-    //- Update solid-liquid mixture properties
-    scalar Cp12 = alpha1_*Cp1.value(T1) + alpha2_*Cp2.value(T2);
-    scalar kappa12 = alpha1_*kappa1.value(T1) + alpha2_*kappa2.value(T2);
-
-    //- Update solid-liquid-powder mixture properties
-    kappa[cellI] = (1.0 - alpha3_)*kappa12 + alpha3_*kappa3.value(T1);
-    Cp[cellI] = (1.0 - alpha3_)*Cp12 + alpha3_*Cp3.value(T1);
+    //- Update solid-liquid-powder mixture properties    
+    kappa[cellI] = 
+        (1.0 - alpha3_)*(alpha1_*kappa1.value(T1) + alpha2_*kappa2.value(T2))
+      + alpha3_*kappa3.value(T1);
+      
+    Cp[cellI] =
+    	(1.0 - alpha3_)*(alpha1_*Cp1.value(T1) + alpha2_*Cp2.value(T2))
+      + alpha3_*Cp3.value(T1);
 }
 
 alpha3.correctBoundaryConditions();
 Cp.correctBoundaryConditions();
 kappa.correctBoundaryConditions();
-
-// smooth discontinuities across continuum powder interface
-kappa = 0.5*fvc::average(kappa + kappa.oldTime());

--- a/tutorials/AMB2018-02-B/system/fvSchemes
+++ b/tutorials/AMB2018-02-B/system/fvSchemes
@@ -32,13 +32,13 @@ divSchemes
 
 laplacianSchemes
 {
-    default         Gauss linear corrected;
+    default             Gauss linear corrected;
+    laplacian(kappa,T)	Gauss harmonic corrected;
 }
 
 interpolationSchemes
 {
     default         linear;
-    interpolate(kappa)  harmonic;
 }
 
 snGradSchemes

--- a/tutorials/marangoni/system/fvSchemes
+++ b/tutorials/marangoni/system/fvSchemes
@@ -32,13 +32,13 @@ divSchemes
 
 laplacianSchemes
 {
-    default         Gauss linear corrected;
+    default             Gauss linear corrected;
+    laplacian(kappa,T)	Gauss harmonic corrected;
 }
 
 interpolationSchemes
 {
     default         linear;
-    interpolate(kappa)  harmonic;
 }
 
 snGradSchemes

--- a/tutorials/multiBeam/system/fvSchemes
+++ b/tutorials/multiBeam/system/fvSchemes
@@ -32,13 +32,13 @@ divSchemes
 
 laplacianSchemes
 {
-    default         Gauss linear corrected;
+    default             Gauss linear corrected;
+    laplacian(kappa,T)	Gauss harmonic corrected;
 }
 
 interpolationSchemes
 {
     default         linear;
-    interpolate(kappa)  harmonic;
 }
 
 snGradSchemes

--- a/tutorials/multiLayerPBF/system/fvSchemes
+++ b/tutorials/multiLayerPBF/system/fvSchemes
@@ -32,13 +32,13 @@ divSchemes
 
 laplacianSchemes
 {
-    default         Gauss linear corrected;
+    default             Gauss linear corrected;
+    laplacian(kappa,T)	Gauss harmonic corrected;
 }
 
 interpolationSchemes
 {
     default         linear;
-    interpolate(kappa)  harmonic;
 }
 
 snGradSchemes


### PR DESCRIPTION
added stabilization to the latent heat source term linearization method and added support for second-order time discretization for the backward (BDF2) scheme. also cleaned up thermophysical properties update to be consistent with Gauss harmonic corrected laplacian scheme.

The near second order converge of the solver using the backward scheme is demonstrated
![image](https://github.com/ORNL/AdditiveFOAM/assets/103219962/033e2e70-8f5c-4f22-bc54-9a5637aed19d)
