### PR TITLE
CI: run on ubuntu-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
         cxx: ['g++']
         cmake_build_type: ['Release']
        
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: docker.io/openfoam/openfoam10-paraview510
       options: --user root


### PR DESCRIPTION
`20.04` is being retired; avoid having to do this in the future with `latest`