### PR TITLE
fix for function object file headers

### DIFF
--- a/tutorials/AMB2018-02-B/Allrun
+++ b/tutorials/AMB2018-02-B/Allrun
@@ -46,13 +46,13 @@ runApplication reconstructPar
 #------------------------------------------------------------------------------
 # Reconstruct function object data
 if [ "$ENABLE_EXACA_DATA" = true ]; then
-    echo "x,y,z,tm,ts,cr" > ExaCA/time-temperature.csv
+    sed '1q' ExaCA/data_* > ExaCA/time-temperature.csv
     tail -q -n+2 ExaCA/data_* >> ExaCA/time-temperature.csv
     rm -rf ExaCA/data_*
 fi
 
 if [ "$ENABLE_SOLIDIFICATION_DATA" = true ]; then
-    echo "x,y,z,ts,cr,g,v" > solidificationData/solidification-data.csv
+    sed '1q' solidificationData/data_* > solidificationData/solidification-data.csv
     tail -q -n+2 solidificationData/data_* >> solidificationData/solidification-data.csv
     rm -rf solidificationData/data_*
 fi

--- a/tutorials/multiBeam/Allrun
+++ b/tutorials/multiBeam/Allrun
@@ -46,13 +46,13 @@ runApplication reconstructPar
 #------------------------------------------------------------------------------
 # Reconstruct function object data
 if [ "$ENABLE_EXACA_DATA" = true ]; then
-    echo "x,y,z,tm,ts,cr" > ExaCA/time-temperature.csv
+    sed '1q' ExaCA/data_* > ExaCA/time-temperature.csv
     tail -q -n+2 ExaCA/data_* >> ExaCA/time-temperature.csv
     rm -rf ExaCA/data_*
 fi
 
 if [ "$ENABLE_SOLIDIFICATION_DATA" = true ]; then
-    echo "x,y,z,ts,cr,g,v" > solidificationData/solidification-data.csv
+    sed '1q' solidificationData/data_* > solidificationData/solidification-data.csv
     tail -q -n+2 solidificationData/data_* >> solidificationData/solidification-data.csv
     rm -rf solidificationData/data_*
 fi

--- a/tutorials/multiLayerPBF/Allrun
+++ b/tutorials/multiLayerPBF/Allrun
@@ -51,7 +51,7 @@ $path/reconstructLayers
 # Reconstruct function object data to layer directories
 if [ "$ENABLE_EXACA_DATA" = true ]; then
     for d in layer*; do
-        echo "x,y,z,tm,ts,cr" > "$d/ExaCA/time-temperature.csv"
+        sed '1q' "$d/ExaCA/data_"* > "$d/ExaCA/time-temperature.csv"
         tail -q -n+2 "$d/ExaCA/data_"* >> "$d/ExaCA/time-temperature.csv"
         rm -rf "$d/ExaCA/data_"*
     done
@@ -59,7 +59,7 @@ fi
 
 if [ "$ENABLE_SOLIDIFICATION_DATA" = true ]; then
     for d in layer*; do    
-        echo "x,y,z,ts,cr,g,v" > "$d/solidificationData/solidification-data.csv"
+        sed '1q' "$d/solidificationData/data_"* > "$d/solidificationData/solidification-data.csv"
         tail -q -n+2 "$d/solidificationData/data_"* >> "$d/solidificationData/solidification-data.csv"
         rm -rf "$d/solidificationData/data_"*
     done


### PR DESCRIPTION
Collaborators have been modifying function objects to output more data, such as the components of the solidification gradient in `solidificationData` rather than just the magnitude. However, when we concatenate these files in `Allrun`, we are assuming the structure of the header. Instead, this fixup uses `sed` to find the header in a file directly. In the future, we might want to have a simple utility to reconstruct files of this structure to reduce repeated code and improve maintainability. 

closes #88 